### PR TITLE
fix: remove TTL index creation for event cleanup in events.py

### DIFF
--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -32,9 +32,6 @@ router = APIRouter()
 UPLOAD_DIR = "uploads"
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
-# Create a TTL index on the "expireAt" field for automatic event cleanup
-events_collection.create_index("expireAt", expireAfterSeconds=0)
-
 def get_current_organization(x_org_email: str = Header(None)):
     if not x_org_email:
         raise HTTPException(status_code=401, detail="Missing authentication header")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7110,9 +7110,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
chore: update vite version to 6.2.5 in package-lock.json